### PR TITLE
Fix wp install path for wpcli

### DIFF
--- a/template/wp-cli.yml
+++ b/template/wp-cli.yml
@@ -1,1 +1,1 @@
-path: web/
+path: web/wp/


### PR DESCRIPTION
Fix the path to the wordpress install for wp-cli.
You then can use wp-cli ✌️