### PR TITLE
Fix a syntax error in the `composer.json` causing errors on install

### DIFF
--- a/saofile.js
+++ b/saofile.js
@@ -106,7 +106,7 @@ module.exports = {
     if (!this.answers.features.includes('acf')) {
       actions.push({
         type: 'remove',
-        files: 'web/wp-content/themes/<?= slug %>/app/Managers/ACFManager.php',
+        files: 'web/wp-content/themes/<%= slug %>/app/Managers/ACFManager.php',
       });
     }
 

--- a/template/composer.json
+++ b/template/composer.json
@@ -94,7 +94,7 @@
   },
   "autoload": {
     "psr-4": {
-      "Studiometa\\": "web/wp-content/themes/<?= slug %>/app"
+      "Studiometa\\": "web/wp-content/themes/<%= slug %>/app"
     }
   },
   "extra": {


### PR DESCRIPTION
This bugfix fixes a syntax error that lead to multiple errors when installing the project because the theme slug couldn't be replaced correctly in the `composer.json` file.