### PR TITLE
Transients manager

### DIFF
--- a/template/web/wp-content/themes/<%= slug %>/app/Managers/README.md
+++ b/template/web/wp-content/themes/<%= slug %>/app/Managers/README.md
@@ -23,6 +23,10 @@ Add functionnality to WordPress
 ## CustomPostTypesManager
 Register custom post types
 
+## TransientsManager
+Bootstraps Transients related functions
+- Run transients cleaner tool if a configuration is specified in `config/transients_cleaner.yml` (see [configuration documentation](https://github.com/studiometa/wp-toolkit/tree/master#transient-cleaner)).
+
 ## TaxonomiesManager
 Register custom taxonomies
 

--- a/template/web/wp-content/themes/<%= slug %>/app/Managers/TransientsManager.php
+++ b/template/web/wp-content/themes/<%= slug %>/app/Managers/TransientsManager.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Bootstraps Transients related functions
+ *
+ * @package Studiometa
+ */
+namespace Studiometa\Managers;
+
+use Studiometa\Managers\ManagerInterface;
+use Studiometa\WPToolkit\TransientCleaner;
+use Symfony\Component\Yaml\Yaml;
+
+/** Class */
+class TransientsManager implements ManagerInterface {
+	// phpcs:ignore Generic.Commenting.DocComment.MissingShort
+	/** @var string Transients cleaner configuration filepath */
+	private $cleaner_config_filepath;
+
+	/**
+	 * Construct.
+	 */
+	public function __construct() {
+		$this->cleaner_config_filepath = sprintf( '%s/config/transients_cleaner.yml', get_template_directory() );
+	}
+
+	/**
+	 * Runs initialization tasks.
+	 * - Initiliaze transients cleaner tool.
+	 *
+	 * @see https://github.com/studiometa/wp-toolkit/tree/master#transient-cleaner
+	 *
+	 * @return void
+	 */
+	public function run() {
+		if ( file_exists( $this->cleaner_config_filepath ) ) {
+			TransientCleaner::get_instance( Yaml::parseFile( $this->cleaner_config_filepath ) );
+		}
+	}
+}

--- a/template/web/wp-content/themes/<%= slug %>/functions.php
+++ b/template/web/wp-content/themes/<%= slug %>/functions.php
@@ -17,6 +17,7 @@ use Studiometa\Managers\CustomPostTypesManager;
 use Studiometa\Managers\ManagerFactory;
 use Studiometa\Managers\TaxonomiesManager;
 use Studiometa\Managers\ThemeManager;
+use Studiometa\Managers\TransientsManager;
 use Studiometa\Managers\TwigManager;
 use Studiometa\Managers\WordPressManager;
 
@@ -58,6 +59,7 @@ add_action(
 	'after_setup_theme',
 	function () {
 		$managers = array(
+			new TransientsManager(),
 			new ThemeManager(),
 			new WordPressManager(),
 			new TwigManager(),


### PR DESCRIPTION
This PR introduce a "Transients Manager" used to manage WordPress transients. This include :
- Run transients cleaner tool from [studiometa/wp-toolkit](https://github.com/studiometa/wp-toolkit/tree/master#transient-cleaner) if a YAML configuration is specified in `config/transients_cleaner.yml`

Closes #45.