### PR TITLE
Feature/update composer dependencies

### DIFF
--- a/template/composer.json
+++ b/template/composer.json
@@ -12,8 +12,6 @@
     "vlucas/phpdotenv": "^3.4",
     "johnpbloch/wordpress": "5.*",
     "timber/timber": "^1.10",
-    "studiometa/wp-mu-cleanup": "^1.0",
-    "studiometa/wp-assets": "dev-feature/v2",
     <%_ if (wpRocket) { _%>
     "wp-media/wp-rocket": "^3.3",
     <%_ } _%>

--- a/template/composer.json
+++ b/template/composer.json
@@ -29,7 +29,8 @@
     "stoutlogic/acf-builder": "^1.10",
     <%_ } _%>
     "lkwdwrd/wp-muplugin-loader": "^1.0",
-    "djboris88/twig-commented-include": "^1.2"
+    "djboris88/twig-commented-include": "^1.2",
+    "studiometa/twig-toolkit": "^1.0"
   },
   "require-dev": {
     "wpackagist-plugin/query-monitor": "^3.6",
@@ -39,7 +40,7 @@
     "dealerdirect/phpcodesniffer-composer-installer": "^0.5.0",
     "phpstan/phpstan": "^0.12.50",
     "szepeviktor/phpstan-wordpress": "^0.6.3",
-    "satesh/phpcs-gitlab-report": "^1.0"
+    "szepeviktor/phpstan-wordpress": "^0.7.1",
   },
   "repositories": [
     {

--- a/template/composer.json
+++ b/template/composer.json
@@ -11,7 +11,7 @@
     "php": "^7.3",
     "vlucas/phpdotenv": "^3.4",
     "johnpbloch/wordpress": "5.*",
-    "timber/timber": "^1.10",
+    "timber/timber": "^1.18.2",
     <%_ if (wpRocket) { _%>
     "wp-media/wp-rocket": "^3.3",
     <%_ } _%>

--- a/template/composer.json
+++ b/template/composer.json
@@ -25,7 +25,7 @@
     "wpackagist-plugin/seo-by-rank-math": "^1.0",
     <%_ } _%>
     <%_ if (acf) { _%>
-    "acf/advanced-custom-fields-pro": "dev-master",
+    "studiometa/advanced-custom-fields-pro": "dev-master",
     "stoutlogic/acf-builder": "^1.10",
     <%_ } _%>
     "lkwdwrd/wp-muplugin-loader": "^1.0",
@@ -46,23 +46,6 @@
       "type": "composer",
       "url": "https://wpackagist.org"
     },
-    <%_ if (acf) { _%>
-    {
-      "type": "package",
-      "package": {
-        "name": "acf/advanced-custom-fields-pro",
-        "type": "wordpress-plugin",
-        "version": "dev-master",
-        "dist": {
-          "type": "zip",
-          "url": "https://github.com/studiometa/advanced-custom-fields-pro/archive/master.zip"
-        },
-        "require": {
-          "composer/installers": "^1.4"
-        }
-      }
-    },
-    <%_ } _%>
     {
       "type": "vcs",
       "url": "https://github.com/tabrisrp/wp-background-processing"

--- a/template/composer.json
+++ b/template/composer.json
@@ -39,8 +39,8 @@
     "wp-cli/wp-cli-bundle": "^2.2",
     "dealerdirect/phpcodesniffer-composer-installer": "^0.5.0",
     "phpstan/phpstan": "^0.12.50",
-    "szepeviktor/phpstan-wordpress": "^0.6.3",
-    "szepeviktor/phpstan-wordpress": "^0.7.1",
+    "szepeviktor/phpstan-wordpress": "^0.7.5",
+    "satesh/phpcs-gitlab-report": "^1.0"
   },
   "repositories": [
     {


### PR DESCRIPTION
## Add
- Add studiometa/twig-toolkit 
- Add ACF [studiometa package](https://github.com/studiometa/advanced-custom-fields-pro)

## Update
- Update timber/timber to 1.18.2
- Update szepeviktor/phpstan-wordpress to 0.7.5

## Remove
- Remove studiometa/wp-mu-cleanup 
- Remove studiometa/wp-assets
- Remove ACF pro 