### PR TITLE
Remove usage of Timber\PostCollection in Repository

### DIFF
--- a/template/web/wp-content/themes/<%= slug %>/app/Repositories/Repository.php
+++ b/template/web/wp-content/themes/<%= slug %>/app/Repositories/Repository.php
@@ -8,8 +8,6 @@
 
 namespace Studiometa\Repositories;
 
-use Timber\PostCollection;
-
 /** Class */
 abstract class Repository {
 	/**
@@ -37,28 +35,6 @@ abstract class Repository {
 	public function first() {
 		$local_array = $this->get();
 		return isset( $local_array[0] ) ? $local_array[0] : null;
-	}
-
-	/**
-	 * Returns a slice of the collection starting at the given index.
-	 * Similar to Laravel's slice().
-	 *
-	 * @param int $start Start index.
-	 *
-	 * @return array
-	 */
-	public function slice( $start ) {
-		$local_array = $this->get();
-
-		if ( count( $local_array ) < 1 ) {
-			return array();
-		}
-
-		if ( is_object( $local_array ) && $local_array instanceof PostCollection ) {
-			$local_array = $local_array->getArrayCopy();
-		}
-
-		return array_slice( $local_array, (int) $start );
 	}
 
 	/**

--- a/template/web/wp-content/themes/<%= slug %>/app/Repositories/Repository.php
+++ b/template/web/wp-content/themes/<%= slug %>/app/Repositories/Repository.php
@@ -1,7 +1,7 @@
 <?php
 /**
- * Parent repository class. Provides a very basic, fluent interface for interacting
- * with PostCollection/PostQuery classes.
+ * Parent repository class. Provides a very basic, fluent interface to interact
+ * with query
  *
  * @package Studiometa
  */
@@ -13,14 +13,14 @@ abstract class Repository {
 	/**
 	 * List of posts.
 	 *
-	 * @var array|PostCollection
+	 * @var array
 	 */
 	private $result_set = array();
 
 	/**
-	 * Returns a list or collection of posts.
+	 * Returns an array of posts.
 	 *
-	 * @return array|PostCollection
+	 * @return array
 	 */
 	public function get() {
 		return $this->result_set;
@@ -73,6 +73,8 @@ abstract class Repository {
 	 *
 	 * @param array $params Query params.
 	 * @return mixed
+	 *
+	 * @example ./app/Repositories/PostRepository.php How to implement do_query().
 	 */
 	abstract protected function do_query( $params );
 
@@ -89,7 +91,7 @@ abstract class Repository {
 	/**
 	 * Returns current result set
 	 *
-	 * @param array|PostCollection $result_set Result set.
+	 * @param array $result_set Result set.
 	 *
 	 * @return Repository
 	 */


### PR DESCRIPTION
### Motivation:
The abstract `Repository` must be more generic.

### Removed
- references to `Timber\PostCollection` are removed
- `Repository->slice()` method is remove. 

Closes #53 and #54