### PR TITLE
Add PHP cross-version compatibility checks

### DIFF
--- a/template/composer.json
+++ b/template/composer.json
@@ -42,6 +42,7 @@
     "phpstan/phpstan": "^0.12.50",
     "szepeviktor/phpstan-wordpress": "^0.7.5",
     "satesh/phpcs-gitlab-report": "^1.0",
+    "phpcompatibility/phpcompatibility-wp": "^2.1.2",
     "roave/security-advisories": "dev-latest"
   },
   "repositories": [

--- a/template/phpcs.xml
+++ b/template/phpcs.xml
@@ -41,6 +41,12 @@
     <exclude-pattern>/app/</exclude-pattern>
   </rule>
 
+  <!-- Run against the PHPCompatibilityWP ruleset -->
+  <rule ref="PHPCompatibilityWP" />
+
+  <!-- Check for cross-version support for PHP 7.3 and higher -->
+  <config name="testVersion" value="7.3-"/>
+
   <!-- Allow usage of `{@inheritdoc}` in doc blocks -->
   <rule ref="Squiz.Commenting.FunctionComment">
     <properties>


### PR DESCRIPTION
This PR will allow us to analyse our code for compatibility with higher and lower versions of PHP. This will ease the process of upgrading PHP version or changing server.