### PR TITLE
Add security advisories to prevent installing packages with known security vulnerabilities

### DIFF
--- a/template/composer.json
+++ b/template/composer.json
@@ -41,7 +41,8 @@
     "dealerdirect/phpcodesniffer-composer-installer": "^0.7.1",
     "phpstan/phpstan": "^0.12.50",
     "szepeviktor/phpstan-wordpress": "^0.7.5",
-    "satesh/phpcs-gitlab-report": "^1.0"
+    "satesh/phpcs-gitlab-report": "^1.0",
+    "roave/security-advisories": "dev-latest"
   },
   "repositories": [
     {


### PR DESCRIPTION
Prevents installation of composer packages with known security vulnerabilities: no API, simply require it.