### PR TITLE
Add Sentry feature (via wp-sentry plugin)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -175,7 +175,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v1
         with:
-          node-version: 12
+          node-version: 16
           registry-url: https://registry.npmjs.org/
 
       - uses: actions/download-artifact@v2

--- a/saofile.js
+++ b/saofile.js
@@ -53,6 +53,7 @@ module.exports = {
         { name: 'Wordfence', value: 'wordfence' },
         { name: 'WP Rocket', value: 'wpRocket' },
         { name: 'Rank Math', value: 'rankMath' },
+        { name: 'Sentry', value: 'sentry' },
       ],
       default: ['acf', 'wpRocket', 'classicEditor'],
     },
@@ -64,6 +65,7 @@ module.exports = {
     const wordfence = features.includes('wordfence');
     const wpRocket = features.includes('wpRocket');
     const rankMath = features.includes('rankMath');
+    const sentry = features.includes('sentry');
 
     return {
       acf,
@@ -71,6 +73,7 @@ module.exports = {
       wordfence,
       wpRocket,
       rankMath,
+      sentry,
     };
   },
   actions() {

--- a/template/.env.example
+++ b/template/.env.example
@@ -34,11 +34,18 @@ AUTH_SALT=''
 SECURE_AUTH_SALT=''
 LOGGED_IN_SALT=''
 NONCE_SALT=''
-
 <%_ if (wpRocket) { _%>
 
 # WP Rocket config
 WP_ROCKET_EMAIL=''
 WP_ROCKET_KEY=''
 WP_CACHE=false
+<%_ } _%>
+<%_ if (sentry) { _%>
+
+# Sentry configuration (https://github.com/stayallive/wp-sentry)
+WP_SENTRY_PHP_DSN=''
+WP_SENTRY_BROWSER_DSN=''
+WP_SENTRY_BROWSER_TRACES_SAMPLE_RATE=false
+WP_SENTRY_ENV=''
 <%_ } _%>

--- a/template/bin/source/wp-config-sample.php
+++ b/template/bin/source/wp-config-sample.php
@@ -118,6 +118,33 @@ define( 'WP_ROCKET_EMAIL', getenv( 'WP_ROCKET_EMAIL' ) );
 define( 'WP_ROCKET_KEY', getenv( 'WP_ROCKET_KEY' ) );
 define( 'WP_CACHE', getenv( 'WP_CACHE' ) === 'true' );
 <%_ } _%>
+<%_ if (sentry) { _%>
+
+/**
+ * Sentry config
+ * @see https://github.com/stayallive/wp-sentry
+ */
+
+$version_file_path = dirname( __DIR__ ) . '/package.json';
+$version = '';
+if ( file_exists( $version_file_path ) ) {
+	$package_content = file_get_contents( $version_file_path );
+
+	if ($package_content) {
+		$package = json_decode( $package_content );
+
+		if ( is_object( $package ) && isset( $package->name, $package->version ) ) {
+			$version = $package->name . '@' . $package->version;
+		}
+	}
+}
+
+define( 'WP_SENTRY_VERSION', $version );
+define( 'WP_SENTRY_PHP_DSN', getenv( 'WP_SENTRY_PHP_DSN' ) );
+define( 'WP_SENTRY_BROWSER_DSN', getenv( 'WP_SENTRY_BROWSER_DSN' ) );
+define( 'WP_SENTRY_BROWSER_TRACES_SAMPLE_RATE', getenv( 'WP_SENTRY_BROWSER_TRACES_SAMPLE_RATE' ) );
+define( 'WP_SENTRY_ENV', (getenv('WP_SENTRY_ENV')) ? getenv('WP_SENTRY_ENV') : getenv('APP_ENV') );
+<%_ } _%>
 
 /* Set default theme */
 define( 'WP_DEFAULT_THEME', '<%= slug %>' );

--- a/template/composer.json
+++ b/template/composer.json
@@ -25,6 +25,9 @@
     <%_ if (rankMath) { _%>
     "wpackagist-plugin/seo-by-rank-math": "^1.0",
     <%_ } _%>
+    <%_ if (sentry) { _%>
+    "stayallive/wp-sentry": "^4.16",
+    <%_ } _%>
     <%_ if (acf) { _%>
     "studiometa/advanced-custom-fields-pro": "^5.9.6",
     "stoutlogic/acf-builder": "^1.10",


### PR DESCRIPTION
Add the plugin [wp-sentry](https://github.com/stayallive/wp-sentry) in SAO.

This plugin add the ability to configure Sentry integration (Issues and Performance), see plugin for more informations.